### PR TITLE
Avoid xml parsing errors

### DIFF
--- a/src/connection/EcdarService.java
+++ b/src/connection/EcdarService.java
@@ -19,7 +19,7 @@ public class EcdarService extends EcdarBackendGrpc.EcdarBackendImplBase {
             List<ComponentProtos.Component> components = request.getComponentsList();
             for (ComponentProtos.Component component: components) {
                 switch (component.getRepCase()){
-                    case JSON : Controller.parseComponentJson(component.getJson());
+                    case JSON : Controller.parseComponentJson(component.getJson()); break;
                     case XML : Controller.parseComponentXml(component.getXml());
                 }
             }


### PR DESCRIPTION
The switch statement is missing a break in EcdarService. Any json component update also tries to parse the empty string as xml causing exceptions.