### PR TITLE
Grpc server address

### DIFF
--- a/src/connection/GrpcServer.java
+++ b/src/connection/GrpcServer.java
@@ -1,7 +1,6 @@
 package connection;
 
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 
 import java.io.IOException;

--- a/src/connection/GrpcServer.java
+++ b/src/connection/GrpcServer.java
@@ -2,18 +2,39 @@ package connection;
 
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.concurrent.TimeUnit;
 
 public class GrpcServer {
 
     private Server server;
 
-    public GrpcServer(int port) {
-        this.server = ServerBuilder.forPort(port)
+    public GrpcServer(String address) {
+        SocketAddress socketAddress = getSocketAddressFromString(address);
+        this.server = NettyServerBuilder.forAddress(socketAddress)
                 .addService(new EcdarService())
                 .build();
+    }
+
+    private SocketAddress getSocketAddressFromString(String address) {
+        int port = 80;
+        String host = null;
+        if (address.indexOf(':') != -1) {
+            String[] arr = address.split(":");
+            host = arr[0];
+            try {
+                port = Integer.parseInt(arr[1]);
+            } catch (NumberFormatException e) {
+                e.printStackTrace();
+            }
+        } else {
+            host = address;
+        }
+        return new InetSocketAddress(host, port);
     }
 
     public void start() throws IOException {

--- a/src/connection/Main.java
+++ b/src/connection/Main.java
@@ -14,7 +14,7 @@ public class Main {
 
     static Option proto = Option.builder("p")
             .longOpt("proto")
-            .argName("port")
+            .argName("address")
             .hasArg()
             .type(Number.class)
             .build();
@@ -56,8 +56,8 @@ public class Main {
             }
 
             if(cmd.hasOption("proto")){
-                int port = ((Number)cmd.getParsedOptionValue("proto")).intValue();
-                GrpcServer server = new GrpcServer(port);
+                String address = cmd.getOptionValue("proto");
+                GrpcServer server = new GrpcServer(address);
                 try {
                     server.start();
                     server.blockUntilShutdown();


### PR DESCRIPTION
Grpc server is now started with the ``-p`` argument followed by the host and port written as ``host:port``
Currently defaults to port 80 if no port is provided