### PR TITLE
Refactor system parsing for queries

### DIFF
--- a/src/antlr/QueryGrammar.g4
+++ b/src/antlr/QueryGrammar.g4
@@ -17,18 +17,29 @@ query       : QUERY_TYPE ':' saveSystem
             | refinement
             ;
 
-refinement  : 'refinement:' system '<=' system
+refinement  : 'refinement:' expression '<=' expression
             ;
 
-saveSystem  : system
-            | system 'save-as' VARIABLE
+saveSystem  : expression
+            | expression 'save-as' VARIABLE
             ;
+
+expression  : conjunction
+            | composition
+            | quotient
+            | system
+            ;
+
+conjunction             : (conjunctionExpression CONJUNCTION)+ conjunctionExpression ;
+conjunctionExpression   : system | composition | quotient ;
+
+composition             : (compositionExpression COMPOSITION)+ compositionExpression ;
+compositionExpression   : system | quotient ;
+
+quotient                : system QUOTIENT system ;
 
 system      : VARIABLE
-            |  '(' system ')'
-            | system CONJUNCTION system
-            | system COMPOSITION system
-            | system QUOTIENT system
+            | '(' expression ')'
             ;
 
 

--- a/test/parser/QueryGrammarTest.java
+++ b/test/parser/QueryGrammarTest.java
@@ -67,9 +67,9 @@ public class QueryGrammarTest {
 
         QueryGrammarParser.QueryContext ctx = parser.queries().query(0);
         assertEquals("get-component", ctx.QUERY_TYPE().getText());
-        assertEquals("A", ctx.saveSystem().system().system(0).system(0).VARIABLE().getText());
-        assertEquals("||", ctx.saveSystem().system().COMPOSITION().getText());
-        assertEquals("F", ctx.saveSystem().system().system(1).VARIABLE().getText());
+        assertEquals("A", ctx.saveSystem().expression().conjunction().conjunctionExpression(0).system().VARIABLE().getText());
+        assertEquals("||", ctx.saveSystem().expression().conjunction().conjunctionExpression(1).composition().COMPOSITION(0).getText());
+        assertEquals("F", ctx.saveSystem().expression().conjunction().conjunctionExpression(1).composition().compositionExpression(1).system().VARIABLE().getText());
     }
 
     @Test
@@ -77,9 +77,9 @@ public class QueryGrammarTest {
         QueryGrammarParser parser = createParserNoError(getTokensFromText("refinement: A <= B \\\\ (A || Q)"));
 
         QueryGrammarParser.QueryContext ctx = parser.queries().query(0);
-        assertEquals("A", ctx.refinement().system(0).VARIABLE().getText());
-        assertEquals("\\\\", ctx.refinement().system(1).QUOTIENT().getText());
-        assertEquals("B", ctx.refinement().system(1).system(0).getText());
+        assertEquals("A", ctx.refinement().expression(0).system().VARIABLE().getText());
+        assertEquals("\\\\", ctx.refinement().expression(1).quotient().QUOTIENT().getText());
+        assertEquals("B", ctx.refinement().expression(1).quotient().system(0).VARIABLE().getText());
     }
 
     @Test
@@ -89,9 +89,9 @@ public class QueryGrammarTest {
         QueryGrammarParser.QueriesContext queriesContext = parser.queries();
         QueryGrammarParser.RefinementContext refinementCtx =queriesContext.query(0).refinement();
         QueryGrammarParser.QueryContext getComponentCtx = queriesContext.query(1);
-        assertEquals("A", refinementCtx.system(0).VARIABLE().getText());
-        assertEquals("B", refinementCtx.system(1).VARIABLE().getText());
-        assertEquals("C", getComponentCtx.saveSystem().system().VARIABLE().getText());
+        assertEquals("A", refinementCtx.expression(0).system().VARIABLE().getText());
+        assertEquals("B", refinementCtx.expression(1).system().VARIABLE().getText());
+        assertEquals("C", getComponentCtx.saveSystem().expression().system().VARIABLE().getText());
         assertEquals("D", getComponentCtx.saveSystem().VARIABLE().getText());
     }
 }

--- a/test/parser/QueryParserTest.java
+++ b/test/parser/QueryParserTest.java
@@ -71,7 +71,7 @@ public class QueryParserTest {
         Field field = QueryParser.class.getDeclaredField("transitionSystems");
         field.setAccessible(true);
         field.set(null, transitionSystems);
-        return visitor.visitSystem(parser.queries().query(0).saveSystem().system());
+        return visitor.visit(parser.queries().query(0).saveSystem().expression());
     }
 
     @Test
@@ -226,7 +226,7 @@ public class QueryParserTest {
     }
     @Test
     public void testDetermOne() throws Exception {
-       assertEquals(Controller.handleRequest("-json ./samples/json/EcdarUniversity", "determinism:HalfAdm1", false).get(0).getResult(), true);
+        assertEquals(Controller.handleRequest("-json ./samples/json/EcdarUniversity", "determinism:HalfAdm1", false).get(0).getResult(), true);
     }
     @Test
     public void testDetermConj() throws Exception {


### PR DESCRIPTION
Systems are no longer only constructed pairwise. This makes the parsing code easier to read and results in less function calls during the parsing 