### PR TITLE
Improve GRPC exception handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,3 +97,19 @@ task submodulesUpdate(type:Exec) {
     commandLine 'git', 'submodule', 'update', '--init', '--recursive'
     group 'Build Setup'
 }
+
+task unpack_without_dll(type:Copy, dependsOn: 'distZip') {
+    def zipFile = file("$buildDir/distributions/j-Ecdar.zip")
+    def outputDir = file("$buildDir/distributions/unpacked")
+    from { zipTree(zipFile) }
+    into outputDir
+    group 'distribution'
+}
+
+task unpack_with_dll(type:Copy, dependsOn: 'unpack_without_dll') {
+    def dll = file("lib/JCDD.dll")
+    def outputDir = file("$buildDir/distributions/unpacked/j-Ecdar/bin")
+    from dll
+    into outputDir
+    group 'distribution'
+}

--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,7 @@ task submodulesUpdate(type:Exec) {
 task unpack_without_dll(type:Copy, dependsOn: 'distZip') {
     def zipFile = file("$buildDir/distributions/j-Ecdar.zip")
     def outputDir = file("$buildDir/distributions/unpacked")
+    delete(outputDir)
     from { zipTree(zipFile) }
     into outputDir
     group 'distribution'

--- a/src/connection/EcdarService.java
+++ b/src/connection/EcdarService.java
@@ -8,10 +8,13 @@ import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import logic.Controller;
 import logic.query.Query;
+import models.CDD;
 
 import java.util.List;
 
 public class EcdarService extends EcdarBackendGrpc.EcdarBackendImplBase {
+
+
 
     @Override
     public void updateComponents(QueryProtos.ComponentsUpdateRequest request,
@@ -26,8 +29,8 @@ public class EcdarService extends EcdarBackendGrpc.EcdarBackendImplBase {
             }
             responseObserver.onNext(Empty.newBuilder().build());
             responseObserver.onCompleted();
-        } catch (Exception e){
-            responseObserver.onError(Status.INVALID_ARGUMENT.withDescription(e.getClass().getName() + ": " + e.getMessage()).asRuntimeException());
+        } catch (Throwable e){
+            responseObserver.onError(Status.INVALID_ARGUMENT.withDescription(tryEnsureDone(e)).asRuntimeException());
         }
     }
 
@@ -73,12 +76,22 @@ public class EcdarService extends EcdarBackendGrpc.EcdarBackendImplBase {
                 default:
                     responseObserver.onError(Status.INVALID_ARGUMENT.withDescription("Query has an invalid type").asRuntimeException());
             }
-
             responseObserver.onNext(queryResponseBuilder.build());
             responseObserver.onCompleted();
-        } catch (Exception e) {
-            responseObserver.onError(Status.INVALID_ARGUMENT.withDescription(e.getClass().getName() + ": " + e.getMessage()).asRuntimeException());
+        } catch (Throwable e) {
+            responseObserver.onError(Status.INVALID_ARGUMENT.withDescription(tryEnsureDone(e)).asRuntimeException());
         }
+    }
+
+    private String tryEnsureDone(Throwable e) {
+        String description = e.getClass().getName() + ": " + e.getMessage();
+
+        try {CDD.ensure_done(); }
+        catch (Throwable ee) {
+            description += "\n" + ee.getClass().getName() + ": " + ee.getMessage();
+        }
+
+        return description;
     }
 
     private void getComponent(Query response, QueryProtos.QueryResponse.Builder queryResponseBuilder) {

--- a/src/connection/GrpcServer.java
+++ b/src/connection/GrpcServer.java
@@ -28,7 +28,7 @@ public class GrpcServer {
             try {
                 port = Integer.parseInt(arr[1]);
             } catch (NumberFormatException e) {
-                e.printStackTrace();
+                throw new RuntimeException(e);
             }
         } else {
             host = address;

--- a/src/connection/Main.java
+++ b/src/connection/Main.java
@@ -69,7 +69,7 @@ public class Main {
                     server.start();
                     server.blockUntilShutdown();
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    throw new RuntimeException(e);
                 }
             }
 
@@ -99,7 +99,7 @@ public class Main {
 
             } catch (Exception e) {
                 System.out.println(e.getMessage());
-                e.printStackTrace();
+                throw new RuntimeException(e);
             }
 
             if(cmd.hasOption("save-to-disk")){

--- a/src/logic/JsonAutomatonEncoder.java
+++ b/src/logic/JsonAutomatonEncoder.java
@@ -64,7 +64,7 @@ public class JsonAutomatonEncoder {
             globalDec.writeJSONString(writer);
             writer.close();
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
 
 

--- a/src/models/CDD.java
+++ b/src/models/CDD.java
@@ -254,6 +254,12 @@ public class CDD {
         CDDLib.cddDone();
     }
 
+    public static void ensure_done(){
+        if (cddIsRunning) {
+            done();
+        }
+    }
+
     public static CDD zeroCDD()
     {
         Zone z = new Zone(numClocks,false);

--- a/src/parser/JSONParser.java
+++ b/src/parser/JSONParser.java
@@ -107,7 +107,7 @@ public class JSONParser {
             }
 
         } catch (Exception e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
 
         return returnList;
@@ -129,15 +129,12 @@ public class JSONParser {
     private static Automaton[] distrubuteObjects(ArrayList<JSONObject> objList, boolean makeInpEnabled) {
         ArrayList<Automaton> automata = new ArrayList<>();
 
-        try {
-            for (JSONObject obj : objList) {
-                if (!obj.get("name").toString().equals("Global Declarations")&&!obj.get("name").toString().equals("System Declarations")) {
-                    automata.add(distrubuteObject(obj, makeInpEnabled));
-                }
+        for (JSONObject obj : objList) {
+            if (!obj.get("name").toString().equals("Global Declarations")&&!obj.get("name").toString().equals("System Declarations")) {
+                automata.add(distrubuteObject(obj, makeInpEnabled));
             }
-        } catch (Exception e) {
-            e.printStackTrace();
         }
+
 
         return automata.toArray(new Automaton[0]);
     }

--- a/src/parser/XMLFileWriter.java
+++ b/src/parser/XMLFileWriter.java
@@ -58,7 +58,7 @@ public class XMLFileWriter {
         try {
             outter.output(doc, new FileWriter(new File(filename)));
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
 
 
@@ -97,7 +97,7 @@ public class XMLFileWriter {
             file.getParentFile().mkdirs();
             outter.output(doc, new FileWriter(file));
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
 
     }

--- a/src/parser/XMLParser.java
+++ b/src/parser/XMLParser.java
@@ -32,7 +32,7 @@ public class XMLParser {
                 automata.add(buildAutomaton(el, makeInpEnabled));
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
 
         return automata.toArray(new Automaton[0]);
@@ -52,7 +52,7 @@ public class XMLParser {
             }
 
         }catch (Exception e){
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
 
         return automata.toArray(new Automaton[0]);
@@ -89,9 +89,8 @@ public class XMLParser {
             Document doc = builder.parse( new InputSource( new StringReader( xmlStr ) ) );
             return doc;
         } catch (Exception e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-        return null;
     }
 
     private static List<Clock> setClocks(Element el) {
@@ -220,7 +219,7 @@ public class XMLParser {
                     if (o.getName().equals("controllable") && o.getBooleanValue()==false) isInput = false;
                 } catch (DataConversionException e) {
                     System.err.println("Controllable flag contains non-boolean value");
-                    e.printStackTrace();
+                    throw new RuntimeException(e);
                 }
 
             }


### PR DESCRIPTION
Makes it so the GRPC interface handles exceptions better allowing it to be used with the test framework without problems: 
Calls CDD.done() if exceptions occur, so next queries can intialize CDD without error.
Changes most usages of e.printStackTrace() to throwing runtime errors instead as critical errors can go missing by just ignoring and printing.
Introduces a new gradle task to unpack the zipped distribution allowing for easy usage with the test framework:
![Showcase](https://i.imgur.com/PerpowF.gif)
(The example uses this branch of j-ecdar along with the main branch of the test framework, and it works!)