### PR TITLE
#40 Specifications are not checked for overlapping input and output action sets

### DIFF
--- a/src/models/Automaton.java
+++ b/src/models/Automaton.java
@@ -17,6 +17,10 @@ public class Automaton {
     private final Location initial;
 
     public Automaton(String name, List<Location> locations, List<Edge> edges, List<Clock> clocks, List<BoolVar> BVs, boolean makeInputEnabled) {
+        if (locations.isEmpty()) {
+            throw new IllegalArgumentException("An automaton msut have atleast one location");
+        }
+
         this.name = name;
         this.locations = locations;
         this.clocks = clocks;

--- a/src/models/Automaton.java
+++ b/src/models/Automaton.java
@@ -102,9 +102,9 @@ public class Automaton {
                     Location target = locations.get(targetIndex);
                     return new Edge(edge, clocks, BVs, source, target, automaton.clocks, automaton.BVs);
                 }).collect(Collectors.toList());
-        inputAct = automaton.inputAct;
-        outputAct = automaton.outputAct;
-        actions = automaton.actions;
+        inputAct = new HashSet<>(automaton.inputAct);
+        outputAct = new HashSet<>(automaton.outputAct);
+        actions = new HashSet<>(automaton.actions);
         initial = new Location(automaton.initial, clocks, automaton.clocks, BVs, automaton.BVs);
     }
 

--- a/src/models/Automaton.java
+++ b/src/models/Automaton.java
@@ -13,7 +13,7 @@ public class Automaton {
     private final List<BoolVar> BVs;
     private final List<Edge> edges;
     private final List<Clock> clocks;
-    private Set<Channel> inputAct, outputAct, actions;
+    private final Set<Channel> inputAct, outputAct, actions;
     private final Location initial;
 
     public Automaton(String name, List<Location> locations, List<Edge> edges, List<Clock> clocks, List<BoolVar> BVs, boolean makeInputEnabled) {

--- a/src/models/Automaton.java
+++ b/src/models/Automaton.java
@@ -35,6 +35,7 @@ public class Automaton {
 
         this.edges = edges;
 
+        // Retrieve the inputs and outputs
         inputAct = new HashSet<>();
         outputAct = new HashSet<>();
         for (Edge edge : this.edges) {
@@ -46,6 +47,23 @@ public class Automaton {
             }
         }
 
+        /* The finite set of actions must be partitioned into inputs and outputs.
+         *   Here we check whether they are partitioned by checking that the intersection of the
+         *   inputs and outputs are empty as an action can only be either an input or an output.
+         *   We don't have to check whether an action is neither an input nor an output as the set
+         *   of actions is build as the union of the inputs and outputs and for this reason
+         *   guarantees to be in the set of actions. */
+        Set<Channel> intersection = new HashSet<>(inputAct);
+        intersection.retainAll(outputAct);
+        if (!intersection.isEmpty()) {
+            throw new IllegalArgumentException("The action set of a specification must be a partition, where each action is either an input xor an output");
+        }
+
+        /* As the inputs and outputs are shown to be disjoint then the union of them
+         *   it holds that the disjoint union of inputs and outputs is a finite set
+         *   of actions partitioned into inputs and outputs. Here the "disjoint" comes
+         *   from actions (or Channels) are reference types and are for this reason not
+         *   merged with actions of the same name. */
         actions = Sets.newHashSet(
                 Iterables.concat(inputAct, outputAct)
         );

--- a/src/models/Automaton.java
+++ b/src/models/Automaton.java
@@ -18,7 +18,7 @@ public class Automaton {
 
     public Automaton(String name, List<Location> locations, List<Edge> edges, List<Clock> clocks, List<BoolVar> BVs, boolean makeInputEnabled) {
         if (locations.isEmpty()) {
-            throw new IllegalArgumentException("An automaton must have atleast one location");
+            throw new IllegalArgumentException(String.format("Automaton %s must have at least one location.", name));
         }
 
         this.name = name;
@@ -30,10 +30,10 @@ public class Automaton {
                 .filter(Location::isInitial)
                 .collect(Collectors.toList());
         if (initialLocations.size() > 1) {
-            throw new IllegalArgumentException("Cannot have more than one initial location");
+            throw new IllegalArgumentException(String.format("Automaton %s cannot have more than one initial location", name));
         }
         if (initialLocations.size() == 0) {
-            throw new IllegalArgumentException("Must have one initial location");
+            throw new IllegalArgumentException(String.format("Automaton %s must have at least one initial location", name));
         }
         initial = initialLocations.get(0);
 
@@ -60,14 +60,15 @@ public class Automaton {
         Set<Channel> intersection = new HashSet<>(inputAct);
         intersection.retainAll(outputAct);
         if (!intersection.isEmpty()) {
-            throw new IllegalArgumentException("The action set of a specification must be a partition, where each action is either an input xor an output");
+            // Constructs a string with the names of the actions violating the partition property as "{a, b, c}"
+            String violatingActions = "{" + intersection
+                    .stream()
+                    .map(Channel::getName)
+                    .collect(Collectors.joining(", ")) + "}";
+            throw new IllegalArgumentException(String.format("The actions %s of specification automaton %s is not a partition.", violatingActions, name));
         }
 
-        /* As the inputs and outputs are shown to be disjoint then the union of them
-         *   it holds that the disjoint union of inputs and outputs is a finite set
-         *   of actions partitioned into inputs and outputs. Here the "disjoint" comes
-         *   from actions (or Channels) are reference types and are for this reason not
-         *   merged with actions of the same name. */
+        /* Since inputAct and outputAct are now disjoint, we can simply construct actions as the union of both sets. */
         actions = Sets.newHashSet(
                 Iterables.concat(inputAct, outputAct)
         );

--- a/src/models/Automaton.java
+++ b/src/models/Automaton.java
@@ -18,7 +18,7 @@ public class Automaton {
 
     public Automaton(String name, List<Location> locations, List<Edge> edges, List<Clock> clocks, List<BoolVar> BVs, boolean makeInputEnabled) {
         if (locations.isEmpty()) {
-            throw new IllegalArgumentException("An automaton msut have atleast one location");
+            throw new IllegalArgumentException("An automaton must have atleast one location");
         }
 
         this.name = name;
@@ -53,7 +53,7 @@ public class Automaton {
 
         /* The finite set of actions must be partitioned into inputs and outputs.
          *   Here we check whether they are partitioned by checking that the intersection of the
-         *   inputs and outputs are empty as an action can only be either an input or an output.
+         *   inputs and outputs are empty as an action can only be either an input xor an output.
          *   We don't have to check whether an action is neither an input nor an output as the set
          *   of actions is build as the union of the inputs and outputs and for this reason
          *   guarantees to be in the set of actions. */

--- a/test/models/AutomatonTest.java
+++ b/test/models/AutomatonTest.java
@@ -5,6 +5,8 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.Assert.*;
+
 public class AutomatonTest {
     @Test(expected = IllegalArgumentException.class)
     public void testActionIsBothAnInputAndOutputThrowsException() {
@@ -98,5 +100,39 @@ public class AutomatonTest {
                 booleans,
                 false
         );
+    }
+
+    @Test
+    public void testCopyConstructorUsesNewReferences() {
+        // Arrange
+        List<Location> locations = new ArrayList<>();
+        locations.add(
+                new Location("Location", new TrueGuard(), true, false, false, false, 0, 0)
+        );
+        List<Edge> edges = new ArrayList<>();
+        List<Clock> clocks = new ArrayList<>();
+        List<BoolVar> booleans = new ArrayList<>();
+        Automaton automaton = new Automaton(
+                "automaton",
+                locations,
+                edges,
+                clocks,
+                booleans,
+                false
+        );
+
+        // Act
+        Automaton copy = new Automaton(automaton);
+
+        // Assert (NotSame checks for != and not !.equals, which is for references)
+        assertNotSame(automaton.getLocations(), copy.getLocations());
+        assertNotSame(automaton.getEdges(), copy.getEdges());
+        assertNotSame(automaton.getActions(), copy.getActions());
+        assertNotSame(automaton.getName(), copy.getName());
+        assertNotSame(automaton.getClocks(), copy.getClocks());
+        assertNotSame(automaton.getInitial(), copy.getInitial());
+        assertNotSame(automaton.getInputAct(), copy.getInputAct());
+        assertNotSame(automaton.getOutputAct(), copy.getOutputAct());
+        assertNotSame(automaton.getBVs(), copy.getBVs());
     }
 }

--- a/test/models/AutomatonTest.java
+++ b/test/models/AutomatonTest.java
@@ -1,0 +1,102 @@
+package models;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AutomatonTest {
+    @Test(expected = IllegalArgumentException.class)
+    public void testActionIsBothAnInputAndOutputThrowsException() {
+        // Arrange
+        Channel channel = new Channel("channel");
+        Location location = new Location("Location", new TrueGuard(), true, false, false, false, 0, 0);
+        List<Location> locations = new ArrayList<>();
+        locations.add(location);
+        List<Edge> edges = new ArrayList<>();
+        edges.add(
+                new Edge(location, location, channel, true, new TrueGuard(), new ArrayList<>())
+        );
+        edges.add(
+                new Edge(location, location, channel, false, new TrueGuard(), new ArrayList<>())
+        );
+        List<Clock> clocks = new ArrayList<>();
+        List<BoolVar> booleans = new ArrayList<>();
+
+        // Act
+        Automaton automaton = new Automaton(
+                "automaton",
+                locations,
+                edges,
+                clocks,
+                booleans,
+                false
+        );
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNoLocationsThrowsException() {
+        // Arrange
+        List<Location> locations = new ArrayList<>();
+        List<Edge> edges = new ArrayList<>();
+        List<Clock> clocks = new ArrayList<>();
+        List<BoolVar> booleans = new ArrayList<>();
+
+        // Act
+        Automaton automaton = new Automaton(
+                "automaton",
+                locations,
+                edges,
+                clocks,
+                booleans,
+                false
+        );
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNoInitialLocationThrowsException() {
+        // Arrange
+        List<Location> locations = new ArrayList<>();
+        locations.add(
+                new Location("Location", new TrueGuard(), false, false, false, false, 0, 0)
+        );
+        List<Edge> edges = new ArrayList<>();
+        List<Clock> clocks = new ArrayList<>();
+        List<BoolVar> booleans = new ArrayList<>();
+
+        // Act
+        Automaton automaton = new Automaton(
+                "automaton",
+                locations,
+                edges,
+                clocks,
+                booleans,
+                false
+        );
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMultipleInitialLocationsThrowsException() {
+        // Arrange
+        List<Location> locations = new ArrayList<>();
+        locations.add(
+                new Location("Location", new TrueGuard(), true, false, false, false, 0, 0)
+        );
+        locations.add(
+                new Location("Location", new TrueGuard(), true, false, false, false, 0, 0)
+        );
+        List<Edge> edges = new ArrayList<>();
+        List<Clock> clocks = new ArrayList<>();
+        List<BoolVar> booleans = new ArrayList<>();
+
+        // Act
+        Automaton automaton = new Automaton(
+                "automaton",
+                locations,
+                edges,
+                clocks,
+                booleans,
+                false
+        );
+    }
+}


### PR DESCRIPTION
The Automaton constructor checks whether an action is either an input xor an output.

# Description
* The main Automaton constructor now checks whether an action is either an input xor output. This is only done in the Automaton constructor (per definition 2) and not in the TransitionSystem (per definition 1), as the TransitionSystem constructor requires an Automaton, and it thereby inherit this property.
* Automaton checks for a minimum of one location in its constructor now.
* Added for tests for the Automaton construction.
* Added a test for Automaton copy constructor
* Fixed the copy constructor for Automaton which did not create new instances of the action sets
* Made addTargetInvariantToEdges and makeInputEnabled private but I expect it to be a part of the public API later. I think for it to be a part of the public API maybe the addTargetInvariantToEdges should be a part of makeInputEnabled.
* Made the action sets finals as a completely new instance of these sets should not be expected throughout the lifetime of an Automaton.

# Related issue
Closes #40 

# How Has This Been Tested?
The added tests for the Automaton, and no test fails because of this change.