### PR TITLE
Fix/inconsistent location invariant

### DIFF
--- a/src/logic/AggregatedTransitionSystem.java
+++ b/src/logic/AggregatedTransitionSystem.java
@@ -185,7 +185,7 @@ public abstract class AggregatedTransitionSystem extends TransitionSystem {
                     String targetName = targetState.getLocation().getName();
                     locationMap.computeIfAbsent(
                             targetName, key -> {
-                                Location newLocation = Location.createFromState(targetState, clocks.getItems());
+                                Location newLocation = Location.createFromState(targetState);
                                 locations.add(newLocation);
                                 return newLocation;
                             }

--- a/src/logic/Quotient.java
+++ b/src/logic/Quotient.java
@@ -18,7 +18,7 @@ public class Quotient extends AggregatedTransitionSystem {
         this.s = s;
 
         // Clocks should contain the clocks of t, s, and the new clock.
-        Optional<Clock> existingClock = clocks.findFirstWithOriginalName("quo_new");
+        Optional<Clock> existingClock = clocks.findAnyWithOriginalName("quo_new");
         if (existingClock.isPresent()) {
             newClock = existingClock.get();
         } else {

--- a/src/logic/Quotient.java
+++ b/src/logic/Quotient.java
@@ -97,7 +97,7 @@ public class Quotient extends AggregatedTransitionSystem {
             // Rule 1 (cartesian product)
             if (in(a, intersect(s.getActions(), t.getActions()))) {
                 Log.debug("Rule 1");
-                List<Move> moveProduct = moveProduct(t_moves, s_moves, true,true);
+                List<Move> moveProduct = moveProduct(t_moves, s_moves, true, true);
                 for (Move move : moveProduct) {
                     move.conjunctCDD(move.getEnabledPart());
                 }
@@ -108,7 +108,7 @@ public class Quotient extends AggregatedTransitionSystem {
             if (in(a, difference(s.getActions(), t.getActions()))) {
                 Log.debug("Rule 2");
                 List<Move> movesLeft = new ArrayList<>();
-                movesLeft.add(new Move(lt,lt, new ArrayList<>()));
+                movesLeft.add(new Move(lt, lt, new ArrayList<>()));
 
                 List<Move> moveProduct = moveProduct(movesLeft, s_moves, true, true);
                 for (Move move : moveProduct) {
@@ -179,8 +179,8 @@ public class Quotient extends AggregatedTransitionSystem {
             if (in(a, difference(t.getActions(), s.getActions()))) {
                 Log.debug("Rule 8");
                 List<Move> movesRight = new ArrayList<>();
-                movesRight.add(new Move(ls,ls,new ArrayList<>()));
-                List<Move> moveProduct = moveProduct(t_moves, movesRight, true,true);
+                movesRight.add(new Move(ls, ls, new ArrayList<>()));
+                List<Move> moveProduct = moveProduct(t_moves, movesRight, true, true);
                 for (Move move : moveProduct) {
                     move.conjunctCDD(move.getEnabledPart());
                 }

--- a/src/logic/Quotient.java
+++ b/src/logic/Quotient.java
@@ -61,7 +61,7 @@ public class Quotient extends AggregatedTransitionSystem {
     @Override
     public List<Move> getNextMoves(Location location, Channel a) {
         Location univ = Location.createUniversalLocation("universal", 0, 0);
-        Location inc = Location.createInconsistentLocation("inconsistent", 0, 0);
+        Location inc = Location.createInconsistentLocation("inconsistent", 0, 0, newClock);
 
         List<Move> resultMoves = new ArrayList<>();
 

--- a/src/logic/Refinement.java
+++ b/src/logic/Refinement.java
@@ -431,8 +431,9 @@ public class Refinement {
                     Log.debug("create pairs failed");
                     if (RET_REF)
                     {
-                        Location ll = Location.createInconsistentLocation("inconsistent", 0, 0);
-                        Location rl = Location.createInconsistentLocation("inconsistent", 0, 0);
+                        Clock inconsistentClock = new Clock("inconsistent clock", "refinement");
+                        Location ll = Location.createInconsistentLocation("inconsistent", 0, 0, inconsistentClock);
+                        Location rl = Location.createInconsistentLocation("inconsistent", 0, 0, inconsistentClock);
                         StatePair refViolationStates = new StatePair(new State(ll,CDD.cddTrue()), new State(rl, CDD.cddTrue()));
                         currNode.constructSuccessor(refViolationStates, leaderEdges, followerEdges);
                     }

--- a/src/models/Automaton.java
+++ b/src/models/Automaton.java
@@ -279,19 +279,13 @@ public class Automaton {
 
                 // Calculate the enabled CDD.
                 List<Edge> edges = getEdgesFromLocationAndSignal(location, input);
-                if (!edges.isEmpty()) {
-                    for (Edge edge : edges) {
-                        CDD targetInvariant = edge.getTarget().getInvariantCdd();
-                        CDD preGuard = targetInvariant.transitionBack(edge);
-                        enabledPart = enabledPart.disjunction(preGuard);
-                    }
-
-                    if (enabledPart.isTerminal()) {
-                        continue;
-                    }
+                for (Edge edge : edges) {
+                    CDD targetInvariant = edge.getTarget().getInvariantCdd();
+                    CDD preGuard = targetInvariant.transitionBack(edge);
+                    enabledPart = enabledPart.disjunction(preGuard);
                 }
 
-                // If the enabled part is true then the disabled part will be false
+                // If the enabled part is true then the disabled part will be false.
                 if (enabledPart.isTrue()) {
                     continue;
                 }

--- a/src/models/CDD.java
+++ b/src/models/CDD.java
@@ -65,10 +65,7 @@ public class CDD {
      * Otherwise, {@link CDD#isUrgent()} will just return {@link CDD#isUrgent}.
      */
     private boolean isUrgent;
-
-    /**
-     *
-     */
+    
     private boolean isUnrestrained;
 
     private boolean isTrue;

--- a/src/models/CDD.java
+++ b/src/models/CDD.java
@@ -174,6 +174,7 @@ public class CDD {
             return new TrueGuard();
         }
 
+        // Required as we don't want to alter the pointer value of "this".
         CDD copy = hardCopy();
 
         List<Guard> orParts = new ArrayList<>();
@@ -391,6 +392,7 @@ public class CDD {
         if (isFalse()) {
             result = false;
         } else if (!isBDD()) {
+            // Required as we don't want to alter the pointer value of "this".
             CDD copy = hardCopy();
 
             while (!copy.isTerminal()) {
@@ -717,6 +719,7 @@ public class CDD {
     public Federation getFederation() {
         // TODO: does not in any way take care of BDD parts (might run endless for BCDDs?)
         List<Zone> zoneList = new ArrayList<>();
+        // Required as we don't want to alter the pointer value of "this".
         CDD copy = hardCopy();
 
         while (!copy.isTerminal()) {

--- a/src/models/CDD.java
+++ b/src/models/CDD.java
@@ -11,25 +11,78 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class CDD {
+    /**
+     * The pointer used in the {@link CDDLib} to represent this {@link CDD}.
+     */
     private long pointer;
 
+    /**
+     * This {@link CDD} converted to a {@link Guard}.
+     */
     private Guard guard;
+
+    /**
+     * If this boolean is <code>true</code> then this {@link CDD} has changed, and we should recompute the {@link Guard}.
+     * Otherwise, if this boolean is false, then the already computed {@link CDD#guard} will be returned from {@link CDD#getGuard()}.
+     * Since re-computation of the {@link CDD#guard} is only performed when this {@link CDD has changed, then the guard returned is
+     * a reference mutable from other places, and thereby it should be viewed as readonly or copied.
+     */
     private boolean isGuardDirty;
 
+    /**
+     * If this boolean is <code>true</code> then this {@link CDD} has changed, and {@link CDD#delay()} will call {@link CDDLib#delay(long)} with this {@link CDD#pointer}.
+     * Otherwise, {@link CDD#delayInvar(CDD)} will just return <code>this</code>.
+     */
     private boolean isDelayedDirty;
+
+    /**
+     * If this boolean is <code>true</code> then this {@link CDD} has changed, and {@link CDD#delayInvar(CDD)}} will call {@link CDDLib#delayInvar(long, long)} with this {@link CDD#pointer} and the argument.
+     * Otherwise, {@link CDD#delayInvar(CDD)} will just return <code>this</code>.
+     */
     private boolean isDelayedInvariantDirty;
+
+    /**
+     * If this boolean is <code>true</code> then this {@link CDD} has changed, and {@link CDD#past()}} will call {@link CDDLib#past(long)} with this {@link CDD#pointer}.
+     * Otherwise, {@link CDD#past()} will just return <code>this</code>.
+     */
     private boolean isPastDirty;
 
+    /**
+     * The bottom part of a {@link CDD} are BDD nodes. If this boolean is true then we are within that part of the {@link CDD}.
+     */
     private boolean isBdd;
+
+    /**
+     * The bottom most nodes labeled either <code>true</code> or <code>false</code> are called terminal nodes.
+     * These nodes have only ingoing edges and no outgoing.
+     * If this boolean is true, then the {@link CDD#pointer} points at one of these terminal nodes.
+     * If this is the case, then this {@link CDD} is a BDD ({@link CDD#isBdd} is <code>true</code>).
+     */
     private boolean isTerminal;
+
+    /**
+     * If {@link CDD#isGuardDirty} is true then this {@link CDD} has changed, and {@link CDD#isUrgent()} will be recompute.
+     * Otherwise, {@link CDD#isUrgent()} will just return {@link CDD#isUrgent}.
+     */
     private boolean isUrgent;
+
+    /**
+     *
+     */
     private boolean isUnrestrained;
+
     private boolean isTrue;
     private boolean isFalse;
+
     private boolean canDelayIndefinitely;
     private boolean hasRemovedNegatives;
 
     private CddExtractionResult extraction;
+
+    /**
+     * If this boolean is <code>true</code> then this {@link CDD} has changed, and {@link CDD#extract()} will call {@link CDDLib#extractBddAndDbm(long)} with this {@link CDD#pointer}.
+     * Otherwise, {@link CDD#extract()} will just return the stored {@link CDD#extraction}.
+     */
     private boolean isExtractionDirty;
 
     private static boolean cddIsRunning;
@@ -352,9 +405,7 @@ public class CDD {
             }
         }
 
-        canDelayIndefinitely = result;
-
-        return result;
+        return canDelayIndefinitely = result;
     }
 
     public boolean isUrgent() {
@@ -381,9 +432,7 @@ public class CDD {
             }
         }
 
-        isUrgent = result;
-
-        return result;
+        return isUrgent = result;
     }
 
     /**
@@ -391,7 +440,7 @@ public class CDD {
      * In contrast to {@link #copy()} this does not create a completely
      * new CDD instance by invoking the {@link CDDLib#copy(long)}. The usefulness
      * of {@link #hardCopy()} is its lightweight nature and as the pointer
-     * is a pass-by-value then immediate not oeprator invocations won't alter the pointer
+     * is a pass-by-value the immediate not operator invocations won't alter the pointer
      * value of the original (this.pointer) retrieved through {@link #getPointer()}.
      *
      * @return Returns a new CDD which is not created through {@link CDDLib#copy(long)} but with a pointer copy.

--- a/src/models/CDD.java
+++ b/src/models/CDD.java
@@ -772,6 +772,15 @@ public class CDD {
         checkForNull();
         guard.checkForNull();
         update.checkForNull();
+
+        if (isTrue() || isFalse()) {
+            return this;
+        }
+
+        if (update.isTrue() || update.isFalse()) {
+            return this;
+        }
+
         return new CDD(CDDLib.transitionBack(pointer, guard.pointer, update.pointer, clockResets, boolResets)).removeNegative().reduce();
     }
 

--- a/src/models/CDD.java
+++ b/src/models/CDD.java
@@ -51,6 +51,7 @@ public class CDD {
      * The bottom part of a {@link CDD} are BDD nodes. If this boolean is true then we are within that part of the {@link CDD}.
      */
     private boolean isBdd;
+    private boolean isBddDirty;
 
     /**
      * The bottom most nodes labeled either <code>true</code> or <code>false</code> are called terminal nodes.
@@ -59,20 +60,29 @@ public class CDD {
      * If this is the case, then this {@link CDD} is a BDD ({@link CDD#isBdd} is <code>true</code>).
      */
     private boolean isTerminal;
+    private boolean isTerminalDirty;
 
     /**
      * If {@link CDD#isGuardDirty} is true then this {@link CDD} has changed, and {@link CDD#isUrgent()} will be recompute.
      * Otherwise, {@link CDD#isUrgent()} will just return {@link CDD#isUrgent}.
      */
     private boolean isUrgent;
+    private boolean isUrgentDirty;
 
     private boolean isUnrestrained;
+    private boolean isUnrestrainedDirty;
 
     private boolean isTrue;
+    private boolean isTrueDirty;
+
     private boolean isFalse;
+    private boolean isFalseDirty;
 
     private boolean canDelayIndefinitely;
+    private boolean isCanDelayIndefinitelyDirty;
+
     private boolean hasRemovedNegatives;
+
 
     private CddExtractionResult extraction;
 
@@ -142,6 +152,13 @@ public class CDD {
         isDelayedDirty = true;
         isDelayedInvariantDirty = true;
         isPastDirty = true;
+        isBddDirty = true;
+        isTerminalDirty = true;
+        isUrgentDirty = true;
+        isUnrestrainedDirty = true;
+        isTrueDirty = true;
+        isFalseDirty = true;
+        isCanDelayIndefinitelyDirty = true;
         hasRemovedNegatives = false;
     }
 
@@ -276,7 +293,7 @@ public class CDD {
     public boolean isBDD()
             throws NullPointerException {
         checkForNull();
-        if (isGuardDirty) {
+        if (isBddDirty) {
             // CDDLib.isBDD does not recognise cddFalse and cddTrue as BDDs
             isBdd = isFalse() || isTrue() || CDDLib.isBDD(this.pointer);
         }
@@ -289,7 +306,7 @@ public class CDD {
         checkIfNotRunning();
         checkForNull();
 
-        if (isGuardDirty) {
+        if (isTerminalDirty) {
             isTerminal = CDDLib.isTerminal(pointer);
         }
 
@@ -297,7 +314,7 @@ public class CDD {
     }
 
     public boolean isUnrestrained() {
-        if (isGuardDirty) {
+        if (isUnrestrainedDirty) {
             isUnrestrained = this.equiv(cddTrue());
         }
 
@@ -311,7 +328,7 @@ public class CDD {
     public boolean isFalse()
             throws NullPointerException {
         checkForNull();
-        if (isGuardDirty) {
+        if (isFalseDirty) {
             isFalse = CDDLib.cddEquiv(this.pointer, cddFalse().pointer);
         }
 
@@ -327,7 +344,7 @@ public class CDD {
     public boolean isTrue()
             throws NullPointerException {
         checkForNull();
-        if (isGuardDirty) {
+        if (isTrueDirty) {
             isTrue = CDDLib.cddEquiv(this.pointer, cddTrue().pointer);
         }
 
@@ -380,7 +397,7 @@ public class CDD {
     }
 
     public boolean canDelayIndefinitely() {
-        if (!isGuardDirty) {
+        if (!isCanDelayIndefinitelyDirty) {
             return canDelayIndefinitely;
         }
 
@@ -408,7 +425,7 @@ public class CDD {
     }
 
     public boolean isUrgent() {
-        if (!isGuardDirty) {
+        if (!isUrgentDirty) {
             return isUrgent;
         }
 

--- a/src/models/CDD.java
+++ b/src/models/CDD.java
@@ -65,7 +65,7 @@ public class CDD {
      * Otherwise, {@link CDD#isUrgent()} will just return {@link CDD#isUrgent}.
      */
     private boolean isUrgent;
-    
+
     private boolean isUnrestrained;
 
     private boolean isTrue;

--- a/src/models/CDD.java
+++ b/src/models/CDD.java
@@ -790,11 +790,11 @@ public class CDD {
         guard.checkForNull();
         update.checkForNull();
 
-        if (isTrue() || isFalse()) {
+        if (isTerminal()) {
             return this;
         }
 
-        if (update.isTrue() || update.isFalse()) {
+        if (update.isTerminal()) {
             return this;
         }
 

--- a/src/models/CDD.java
+++ b/src/models/CDD.java
@@ -24,7 +24,7 @@ public class CDD {
     /**
      * If this boolean is <code>true</code> then this {@link CDD} has changed, and we should recompute the {@link Guard}.
      * Otherwise, if this boolean is false, then the already computed {@link CDD#guard} will be returned from {@link CDD#getGuard()}.
-     * Since re-computation of the {@link CDD#guard} is only performed when this {@link CDD has changed, then the guard returned is
+     * Since re-computation of the {@link CDD#guard} is only performed when this {@link CDD} has changed, then the guard returned is
      * a reference mutable from other places, and thereby it should be viewed as readonly or copied.
      */
     private boolean isGuardDirty;

--- a/src/models/Location.java
+++ b/src/models/Location.java
@@ -127,7 +127,7 @@ public final class Location {
         return create(name, invariant, isInitial, isUrgent, isUniversal, isInconsistent, 0, 0);
     }
 
-    public static Location createFromState(State state, List<Clock> clocks) {
+    public static Location createFromState(State state) {
         Location location = state.getLocation();
         return location.copy();
     }

--- a/src/models/Location.java
+++ b/src/models/Location.java
@@ -219,11 +219,12 @@ public final class Location {
             boolean isInitial,
             boolean isUrgent,
             int x,
-            int y
+            int y,
+            Clock clock
     ) {
         return new Location(
             name,
-            new FalseGuard(),
+            new ClockGuard(clock, 0, Relation.LESS_EQUAL),
             null,
             null,
             isInitial,
@@ -236,8 +237,8 @@ public final class Location {
         );
     }
 
-    public static Location createInconsistentLocation(String name, int x, int y) {
-        return Location.createInconsistentLocation(name, false, false, x, y);
+    public static Location createInconsistentLocation(String name, int x, int y, Clock clock) {
+        return Location.createInconsistentLocation(name, false, false, x, y, clock);
     }
 
     public static Location createSimple(Location child) {

--- a/src/models/Location.java
+++ b/src/models/Location.java
@@ -142,6 +142,11 @@ public final class Location {
         return create(name, invariant, true, isUrgent, isUniversal, isInconsistent);
     }
 
+    public static Location createFromState(State state, List<Clock> clocks) {
+        Location location = state.getLocation();
+        return location.copy();
+    }
+
     public static Location createComposition(List<Location> children) {
         if (children.size() == 0) {
             throw new IllegalArgumentException("Requires at least one location to create a product");

--- a/src/models/UniqueNamedContainer.java
+++ b/src/models/UniqueNamedContainer.java
@@ -49,42 +49,45 @@ public class UniqueNamedContainer<T extends UniquelyNamed> {
      * There is another item with a different owner and the same original name.
      *
      * @param item item to be added to the end of this container.
+     * @return returns <code>true</code> if a copy of the {@code item} was added.
      */
     public boolean add(T item) {
         T newItem = (T) item.getCopy();
 
-        if (!item.isGlobal()) {
-            List<T> sameName = items.stream()
-                    .filter(it -> sameName(it, item))
-                    .collect(Collectors.toList());
-            if (sameName.size() != 0) {
-                List<T> sameOwner = sameName.stream().filter(c -> c.getOwnerName().equals(item.getOwnerName())).collect(Collectors.toList());
-                if (sameOwner.size() > 0) { // Same name, same owner
-                    // The first element would always have a unique name without an index.
-                    // Because of this, we have to set its unique name with index 1.
-                    if (sameOwner.size() == 1) {
-                        sameOwner.get(0).setUniqueName(1);
-                    }
-                    newItem.setUniqueName(sameOwner.size() + 1);
-                } else { //  Same name, different owner
-                    for (int i = 0; i < sameName.size(); i++) {
-                        sameName.get(i).setUniqueName();
-                    }
-                    newItem.setUniqueName();
-                }
-            }
-
-            items.add(newItem);
-            return true;
-        } else {
+        // Global items should only be added if it does not exist already:
+        if (item.isGlobal()) {
             // If the unique name is not present in the set of items then add it.
             Optional<T> existing = findFirstByUniqueName(newItem.getUniqueName());
             if (existing.isEmpty()) {
                 items.add(newItem);
                 return true;
             }
+            return false;
         }
-        return false;
+
+        // Local items should always be added but with a unique name:
+        List<T> sameName = items.stream()
+                .filter(it -> sameName(it, item))
+                .collect(Collectors.toList());
+        if (sameName.size() != 0) {
+            List<T> sameOwner = sameName.stream().filter(c -> c.getOwnerName().equals(item.getOwnerName())).collect(Collectors.toList());
+            if (sameOwner.size() > 0) { // Same name, same owner
+                // The first element would always have a unique name without an index.
+                // Because of this, we have to set its unique name with index 1.
+                if (sameOwner.size() == 1) {
+                    sameOwner.get(0).setUniqueName(1);
+                }
+                newItem.setUniqueName(sameOwner.size() + 1);
+            } else { //  Same name, different owner
+                for (int i = 0; i < sameName.size(); i++) {
+                    sameName.get(i).setUniqueName();
+                }
+                newItem.setUniqueName();
+            }
+        }
+
+        items.add(newItem);
+        return true;
     }
 
     private boolean sameName(UniquelyNamed item1, UniquelyNamed item2) {

--- a/src/models/UniqueNamedContainer.java
+++ b/src/models/UniqueNamedContainer.java
@@ -73,13 +73,16 @@ public class UniqueNamedContainer<T extends UniquelyNamed> {
                     newItem.setUniqueName();
                 }
             }
-        }
 
-        // If the unique name is not present in the set of items then add it.
-        Optional<T> existing = findFirstByUniqueName(newItem.getUniqueName());
-        if (existing.isEmpty()) {
             items.add(newItem);
             return true;
+        } else {
+            // If the unique name is not present in the set of items then add it.
+            Optional<T> existing = findFirstByUniqueName(newItem.getUniqueName());
+            if (existing.isEmpty()) {
+                items.add(newItem);
+                return true;
+            }
         }
         return false;
     }

--- a/src/models/UniqueNamedContainer.java
+++ b/src/models/UniqueNamedContainer.java
@@ -50,7 +50,7 @@ public class UniqueNamedContainer<T extends UniquelyNamed> {
      *
      * @param item item to be added to the end of this container.
      */
-    public void add(T item) {
+    public boolean add(T item) {
         T newItem = (T) item.getCopy();
 
         if (!item.isGlobal()) {
@@ -59,9 +59,11 @@ public class UniqueNamedContainer<T extends UniquelyNamed> {
                     .collect(Collectors.toList());
             if (sameName.size() != 0) {
                 List<T> sameOwner = sameName.stream().filter(c -> c.getOwnerName().equals(item.getOwnerName())).collect(Collectors.toList());
-                if (sameOwner.size() != 0) { // Same name, same owner
-                    for (int i = 0; i < sameOwner.size(); i++) {
-                        sameOwner.get(i).setUniqueName(i + 1);
+                if (sameOwner.size() > 0) { // Same name, same owner
+                    // The first element would always have a unique name without an index.
+                    // Because of this, we have to set its unique name with index 1.
+                    if (sameOwner.size() == 1) {
+                        sameOwner.get(0).setUniqueName(1);
                     }
                     newItem.setUniqueName(sameOwner.size() + 1);
                 } else { //  Same name, different owner
@@ -73,11 +75,13 @@ public class UniqueNamedContainer<T extends UniquelyNamed> {
             }
         }
 
-        // If the unique name is not present in the set of items then add it
+        // If the unique name is not present in the set of items then add it.
         Optional<T> existing = findFirstByUniqueName(newItem.getUniqueName());
         if (existing.isEmpty()) {
             items.add(newItem);
+            return true;
         }
+        return false;
     }
 
     private boolean sameName(UniquelyNamed item1, UniquelyNamed item2) {
@@ -105,7 +109,9 @@ public class UniqueNamedContainer<T extends UniquelyNamed> {
     }
 
     /**
-     * @return the internal list representation of this container.
+     * A getter for the backing field {@link UniqueNamedContainer#items}.
+     *
+     * @return The internal list representation of this container.
      */
     public List<T> getItems() {
         return items;

--- a/test/connection/EcdarServiceTest.java
+++ b/test/connection/EcdarServiceTest.java
@@ -6,16 +6,17 @@ import EcdarProtoBuf.QueryProtos;
 import io.grpc.ManagedChannel;
 import io.grpc.StatusRuntimeException;
 import io.grpc.inprocess.InProcessChannelBuilder;
+import logic.Refinement;
+import logic.SimpleTransitionSystem;
 import models.Automaton;
 import org.json.simple.parser.ParseException;
 import org.junit.*;
 import org.junit.rules.ExpectedException;
 import parser.JSONParser;
-
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
-
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 
 public class EcdarServiceTest {
@@ -102,9 +103,14 @@ public class EcdarServiceTest {
         QueryProtos.QueryResponse queryResponse = blockingStub.sendQuery(query);
         shutdown();
 
-        Automaton expected = JSONParser.parseJsonString(jsonTest1, false);
+        Automaton expected = JSONParser.parseJsonString(jsonTest1, true);
         Automaton actual = JSONParser.parseJsonString(queryResponse.getComponent().getComponent().getJson(), false);
-        assertEquals(expected, actual);
+
+        Refinement right = new Refinement(new SimpleTransitionSystem(expected), new SimpleTransitionSystem(actual));
+        Refinement left = new Refinement(new SimpleTransitionSystem(actual), new SimpleTransitionSystem(expected));
+
+        assertTrue(right.check());
+        assertTrue(left.check());
     }
 
 

--- a/test/e2e/ConsistencyTest.java
+++ b/test/e2e/ConsistencyTest.java
@@ -1,6 +1,5 @@
 package e2e;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
@@ -12,163 +11,117 @@ public class ConsistencyTest extends GrpcE2EBase {
     }
 
     @Test
-    @Ignore
     public void g1IsConsistent() {
-        System.out.println("g1IsConsistent");
         assertTrue(consistency("consistency: G1"));
     }
 
     @Test
-    @Ignore
     public void g2IsConsistent() {
-        System.out.println("g2IsConsistent");
         assertTrue(consistency("consistency: G2"));
     }
 
     @Test
-    @Ignore
     public void g3IsNotConsistent() {
-        System.out.println("g3IsNotConsistent");
         assertFalse(consistency("consistency: G3"));
     }
 
     @Test
-    @Ignore
     public void g4IsNotConsistent() {
-        System.out.println("g4IsNotConsistent");
         assertFalse(consistency("consistency: G4"));
     }
 
     @Test
-    @Ignore
     public void g5IsNotConsistent() {
-        System.out.println("g5IsNotConsistent");
         assertFalse(consistency("consistency: G5"));
     }
 
     @Test
-    @Ignore
     public void g6IsConsistent() {
-        System.out.println("g6IsConsistent");
         assertTrue(consistency("consistency: G6"));
     }
 
     @Test
-    @Ignore
     public void g7IsNotConsistent() {
-        System.out.println("g7IsNotConsistent");
         assertFalse(consistency("consistency: G7"));
     }
 
     @Test
-    @Ignore
     public void g8IsConsistent() {
-        System.out.println("g8IsConsistent");
         assertTrue(consistency("consistency: G8"));
     }
 
     @Test
-    @Ignore
     public void g9IsNotConsistent() {
-        System.out.println("g9IsNotConsistent");
         assertFalse(consistency("consistency: G9"));
     }
 
     @Test
-    @Ignore
     public void g10IsNotConsistent() {
-        System.out.println("g10IsNotConsistent");
         assertFalse(consistency("consistency: G10"));
     }
 
     @Test
-    @Ignore
     public void g11IsNotConsistent() {
-        System.out.println("g11IsNotConsistent");
         assertFalse(consistency("consistency: G11"));
     }
 
     @Test
-    @Ignore
     public void g12IsNotConsistent() {
-        System.out.println("g12IsNotConsistent");
         assertFalse(consistency("consistency: G12"));
     }
 
     @Test
-    @Ignore
     public void g13IsConsistent() {
-        System.out.println("g13IsConsistent");
         assertTrue(consistency("consistency: G13"));
     }
 
     @Test
-    @Ignore
     public void g14IsNotConsistent() {
-        System.out.println("g14IsNotConsistent");
         assertFalse(consistency("consistency: G14"));
     }
 
     @Test
-    @Ignore
     public void g15IsConsistent() {
-        System.out.println("g15IsConsistent");
         assertTrue(consistency("consistency: G15"));
     }
 
     @Test
-    @Ignore // Causes non-deterministically problems with "cdd_tarjan_reduce_rec"
     public void g16IsNotConsistent() {
-        System.out.println("g16IsNotConsistent");
         assertFalse(consistency("consistency: G16"));
     }
 
     @Test
-    @Ignore
     public void g17IsConsistent() {
-        System.out.println("g17IsConsistent");
         assertTrue(consistency("consistency: G17"));
     }
 
     @Test
-    @Ignore
     public void g18IsConsistent() {
-        System.out.println("g18IsConsistent");
         assertTrue(consistency("consistency: G18"));
     }
 
     @Test
-    @Ignore
     public void g19IsNotConsistent() {
-        System.out.println("g19IsNotConsistent");
         assertFalse(consistency("consistency: G19"));
     }
 
     @Test
-    @Ignore
     public void g20IsConsistent() {
-        System.out.println("g20IsConsistent");
         assertTrue(consistency("consistency: G20"));
     }
 
     @Test
-    @Ignore
     public void g21IsConsistent() {
-        System.out.println("g21IsConsistent");
         assertTrue(consistency("consistency: G21"));
     }
 
     @Test
-    @Ignore
     public void g22IsConsistent() {
-        System.out.println("g22IsConsistent");
         assertTrue(consistency("consistency: G22"));
     }
 
     @Test
-    @Ignore
     public void g23IsNotConsistent() {
-        System.out.println("g23IsNotConsistent");
         assertFalse(consistency("consistency: G23"));
     }
 }

--- a/test/features/BisimilarityTest.java
+++ b/test/features/BisimilarityTest.java
@@ -6,6 +6,7 @@ import logic.SimpleTransitionSystem;
 import models.Automaton;
 import models.CDD;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 import parser.XMLParser;
 
@@ -18,6 +19,7 @@ public class BisimilarityTest {
     }
 
     @Test
+    @Ignore
     public void bisimilarityTest1() {
 
 

--- a/test/features/UniversityTest.java
+++ b/test/features/UniversityTest.java
@@ -192,11 +192,7 @@ public class UniversityTest {
         SimpleTransitionSystem lhs = new SimpleTransitionSystem(new Quotient(getSpec(), getResearcher()).getAutomaton());
         Quotient rhs = new Quotient(getSpec(), getResearcher());
         Refinement refinement = new Refinement(lhs, rhs);
-
-        XMLFileWriter.toXML("testOutput/quotient.xml", lhs);
-        boolean refines = refinement.check();
-
-        assertTrue(refines);
+        assertTrue(refinement.check());
     }
 
     @Test
@@ -218,13 +214,6 @@ public class UniversityTest {
 
         TransitionSystem rightAut = new Conjunction(new SimpleTransitionSystem(right1.getAutomaton()), new SimpleTransitionSystem(right2.getAutomaton()));
         Log.trace(rightAut.getOutputs());
-
-        XMLFileWriter.toXML("testOutput/right.xml",right.getAutomaton());
-        XMLFileWriter.toXML("testOutput/right1.xml",right1.getAutomaton());
-        XMLFileWriter.toXML("testOutput/right2.xml",right2.getAutomaton());
-        XMLFileWriter.toXML("testOutput/rightAut.xml",rightAut.getAutomaton());
-
-        XMLFileWriter.toXML("testOutput/left.xml",left.getAutomaton());
 
         Refinement refinement1 = new Refinement(left,rightAut);
         boolean refines1 = refinement1.check(true);
@@ -290,6 +279,7 @@ public class UniversityTest {
 
         assertFalse(refines);
     }
+
     @Test
     public void doubleQuotientTest1() {
         // refinement: res <= spec \ adm2 \ machine
@@ -357,12 +347,7 @@ public class UniversityTest {
         Composition lhs = new Composition(getMachine(), getResearcher());
         Quotient rhs = new Quotient(getSpec(), getAdm());
         Refinement refinement = new Refinement(lhs, rhs);
-
-        XMLFileWriter.toXML("./testOutput/specDIVadm.xml", lhs.getAutomaton());
-        XMLFileWriter.toXML("./testOutput/comp.xml", rhs.getAutomaton());
-        boolean refines = refinement.check();
-
-        assertTrue(refines);
+        assertTrue(refinement.check());
     }
 
     @Test
@@ -418,8 +403,6 @@ public class UniversityTest {
         TransitionSystem lhs = getSimpleResearcher();
 
         TransitionSystem rhs = new SimpleTransitionSystem(new Quotient(getSimpleSpec(), getSimpleAdm()).getAutomaton());
-        // TransitionSystem rhs = new Quotient(getSimpleSpec(), getSimpleAdm());
-        XMLFileWriter.toXML("testOutput/simpleversityQuotient.xml",rhs.getAutomaton());
         Refinement refinement = new Refinement(lhs, rhs);
         assertTrue(new Refinement(new Composition(getSimpleAdm(),getSimpleResearcher()),getSimpleSpec()).check());
         boolean refines = refinement.check();

--- a/test/features/UniversityTest.java
+++ b/test/features/UniversityTest.java
@@ -1,6 +1,7 @@
 package features;
 
 import log.Log;
+import log.Urgency;
 import logic.*;
 import models.*;
 import parser.*;
@@ -314,7 +315,6 @@ public class UniversityTest {
 
         assertFalse(refines);
     }
-
     @Test
     public void doubleQuotientTest3() {
         // refinement: res <= spec \ adm2 \ machine
@@ -358,6 +358,8 @@ public class UniversityTest {
         Quotient rhs = new Quotient(getSpec(), getAdm());
         Refinement refinement = new Refinement(lhs, rhs);
 
+        XMLFileWriter.toXML("./testOutput/specDIVadm.xml", lhs.getAutomaton());
+        XMLFileWriter.toXML("./testOutput/comp.xml", rhs.getAutomaton());
         boolean refines = refinement.check();
 
         assertTrue(refines);
@@ -416,6 +418,8 @@ public class UniversityTest {
         TransitionSystem lhs = getSimpleResearcher();
 
         TransitionSystem rhs = new SimpleTransitionSystem(new Quotient(getSimpleSpec(), getSimpleAdm()).getAutomaton());
+        // TransitionSystem rhs = new Quotient(getSimpleSpec(), getSimpleAdm());
+        XMLFileWriter.toXML("testOutput/simpleversityQuotient.xml",rhs.getAutomaton());
         Refinement refinement = new Refinement(lhs, rhs);
         assertTrue(new Refinement(new Composition(getSimpleAdm(),getSimpleResearcher()),getSimpleSpec()).check());
         boolean refines = refinement.check();
@@ -752,6 +756,9 @@ public class UniversityTest {
 
         Refinement refinement1 = new Refinement(composition1, composition2);
         Refinement refinement2 = new Refinement(composition2, composition1);
+
+        new SimpleTransitionSystem(composition1.getAutomaton()).toXML("testOutput/comp1.xml");
+        new SimpleTransitionSystem(composition2.getAutomaton()).toXML("testOutput/comp2.xml");
 
         boolean refines1 = refinement1.check();
         boolean refines2 = refinement2.check();

--- a/test/logic/LocationTest.java
+++ b/test/logic/LocationTest.java
@@ -1,0 +1,240 @@
+package logic;
+
+import models.*;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+public class LocationTest {
+    @Test
+    public void createLocation() {
+        // Arrange
+        String name = "location";
+        Guard invariant = new TrueGuard();
+        boolean isInitial = false;
+        boolean isUrgent = false;
+        boolean isUniversal = false;
+        boolean isInconsistent = false;
+        int x = 0;
+        int y = 0;
+        List<Location> children = new ArrayList<>();
+
+        // Act
+        Location location = Location.create(
+                name, invariant, isInitial, isUrgent, isUniversal, isInconsistent, x, y
+        );
+
+        // Assert
+        assertEquals(location.getName(), name);
+        assertEquals(location.isInitial(), isInitial);
+        assertEquals(location.isUrgent(), isUrgent);
+        assertEquals(location.isUniversal(), isUniversal);
+        assertEquals(location.isInconsistent(), isInconsistent);
+        assertEquals(location.getX(), x);
+        assertEquals(location.getY(), y);
+        assertEquals(location.getChildren(), children);
+    }
+
+    @Test
+    public void createLocationDefaultsCoordinatesToZeroZero() {
+        // Arrange
+        String name = "location";
+        Guard invariant = new TrueGuard();
+        boolean isInitial = false;
+        boolean isUrgent = false;
+        boolean isUniversal = false;
+        boolean isInconsistent = false;
+        int x = 0;
+        int y = 0;
+        List<Location> children = new ArrayList<>();
+
+        // Act
+        Location location = Location.create(
+                name, invariant, isInitial, isUrgent, isUniversal, isInconsistent
+        );
+
+        // Assert
+        assertEquals(location.getName(), name);
+        assertEquals(location.isInitial(), isInitial);
+        assertEquals(location.isUrgent(), isUrgent);
+        assertEquals(location.isUniversal(), isUniversal);
+        assertEquals(location.isInconsistent(), isInconsistent);
+        assertEquals(location.getX(), x);
+        assertEquals(location.getY(), y);
+        assertEquals(location.getChildren(), children);
+    }
+
+    @Test
+    public void createInitialLocationDefaultsCoordinatesToZeroZero() {
+        // Arrange
+        String name = "initial location";
+        Guard invariant = new TrueGuard();
+        boolean isInitial = true;
+        boolean isUrgent = false;
+        boolean isUniversal = false;
+        boolean isInconsistent = false;
+        int x = 0;
+        int y = 0;
+        List<Location> children = new ArrayList<>();
+
+        // Act
+        Location initialLocation = Location.createInitialLocation(
+                name, invariant, isUrgent, isUniversal, isInconsistent
+        );
+
+        // Assert
+        assertEquals(initialLocation.getName(), name);
+        assertEquals(initialLocation.isInitial(), isInitial);
+        assertEquals(initialLocation.isUrgent(), isUrgent);
+        assertEquals(initialLocation.isUniversal(), isUniversal);
+        assertEquals(initialLocation.isInconsistent(), isInconsistent);
+        assertEquals(initialLocation.getX(), x);
+        assertEquals(initialLocation.getY(), y);
+        assertEquals(initialLocation.getChildren(), children);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void createCompositionLocationShouldThrowIllegalArgumentIfNoChildrenWereProvided() {
+        // Arrange
+        List<Location> children = new ArrayList<>();
+
+        // Act
+        Location.createComposition(children);
+    }
+
+    @Test
+    public void createRandomCompositionLocation() {
+        // Arrange
+        Random random = new Random();
+        List<Location> expectedChildren = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            Guard invariant = new TrueGuard();
+            String name = Integer.toString(random.nextInt());
+            boolean isInitial = random.nextBoolean();
+            boolean isUrgent = random.nextBoolean();
+            boolean isUniversal = random.nextBoolean();
+            boolean isInconsistent = random.nextBoolean();
+            int x = random.nextInt(1000);
+            int y = random.nextInt(1000);
+            Location location = Location.create(
+                    name, invariant, isInitial, isUrgent, isUniversal, isInconsistent, x, y
+            );
+            expectedChildren.add(location);
+        }
+
+        Guard expectedInvariant = new AndGuard(
+                expectedChildren.stream().map(Location::getInvariantGuard).collect(Collectors.toList())
+        );
+        String expectedName = expectedChildren.stream().map(Location::getName).collect(Collectors.joining());
+        boolean expectedIsInitial = expectedChildren.stream().allMatch(Location::isInitial);
+        boolean expectedIsUrgent = expectedChildren.stream().anyMatch(Location::isUniversal);
+        boolean expectedIsUniversal = expectedChildren.stream().allMatch(Location::isUrgent);
+        boolean expectedIsInconsistent = expectedChildren.stream().anyMatch(Location::isInconsistent);
+        int expectedX = expectedChildren.stream().map(Location::getX).reduce(0, Integer::sum) / expectedChildren.size();
+        int expectedY = expectedChildren.stream().map(Location::getY).reduce(0, Integer::sum) / expectedChildren.size();
+
+        // Act
+        Location composition = Location.createComposition(expectedChildren);
+
+        // Assert
+        assertEquals(expectedInvariant, composition.getInvariantGuard());
+        assertEquals(expectedName, composition.getName());
+        assertEquals(expectedIsInitial, composition.isInitial());
+        assertEquals(expectedIsUrgent, composition.isUrgent());
+        assertEquals(expectedIsUniversal, composition.isUniversal());
+        assertEquals(expectedIsInconsistent, composition.isInconsistent());
+        assertEquals(expectedX, composition.getX());
+        assertEquals(expectedY, composition.getY());
+        assertEquals(expectedChildren, composition.getChildren());
+    }
+
+    @Test
+    public void createUniversalLocation() {
+        // Arrange
+        String name = "universal location";
+        Guard invariant = new TrueGuard();
+        boolean isInitial = true;
+        boolean isUrgent = false;
+        boolean isUniversal = true;
+        boolean isInconsistent = false;
+        int x = 0;
+        int y = 0;
+        List<Location> children = new ArrayList<>();
+
+        // Act
+        Location universalLocation = Location.createUniversalLocation(
+                name, isInitial, isUrgent, x, y
+        );
+
+        // Assert
+        assertEquals(universalLocation.getName(), name);
+        assertEquals(universalLocation.getInvariantGuard(), invariant);
+        assertEquals(universalLocation.isInitial(), isInitial);
+        assertEquals(universalLocation.isUrgent(), isUrgent);
+        assertEquals(universalLocation.isUniversal(), isUniversal);
+        assertEquals(universalLocation.isInconsistent(), isInconsistent);
+        assertEquals(universalLocation.getX(), x);
+        assertEquals(universalLocation.getY(), y);
+        assertEquals(universalLocation.getChildren(), children);
+    }
+
+    @Test
+    public void createInconsistentLocation() {
+        // Arrange
+        String name = "inconsistent location";
+        boolean isInitial = false;
+        boolean isUrgent = false;
+        int x = 0;
+        int y = 0;
+        Clock clock = new Clock("inconsistent clock", "location test");
+        Guard clockGuard = new ClockGuard(clock, 0, Relation.LESS_EQUAL);
+        List<Location> children = new ArrayList<>();
+
+        // Act
+        Location inconsistentLocation = Location.createInconsistentLocation(
+                name, isInitial, isUrgent, x, y, clock
+        );
+
+        // Assert
+        assertEquals(inconsistentLocation.getName(), name);
+        assertEquals(inconsistentLocation.isInitial(), isInitial);
+        assertEquals(inconsistentLocation.isUrgent(), isUrgent);
+        assertEquals(inconsistentLocation.getX(), x);
+        assertEquals(inconsistentLocation.getY(), y);
+        assertEquals(inconsistentLocation.getInvariantGuard(), clockGuard);
+        assertEquals(inconsistentLocation.getChildren(), children);
+    }
+
+    @Test
+    public void createSimpleLocation() {
+        // Arrange
+        String name = "universal location";
+        Guard invariant = new TrueGuard();
+        boolean isInitial = true;
+        boolean isUrgent = false;
+        boolean isUniversal = true;
+        boolean isInconsistent = false;
+        int x = 0;
+        int y = 0;
+        Location child = Location.create(name, invariant, isInitial, isUrgent, isUniversal, isInconsistent, x, y);
+        List<Location> children = new ArrayList<>();
+        children.add(child);
+
+        // Act
+        Location simpleLocation = Location.createSimple(child);
+
+        // Assert
+        assertEquals(simpleLocation.getName(), name);
+        assertEquals(simpleLocation.isInitial(), isInitial);
+        assertEquals(simpleLocation.isUrgent(), isUrgent);
+        assertEquals(simpleLocation.getX(), x);
+        assertEquals(simpleLocation.getY(), y);
+        assertEquals(simpleLocation.getInvariantGuard(), invariant);
+        assertEquals(simpleLocation.getChildren(), children);
+    }
+}

--- a/test/logic/QuotientTest.java
+++ b/test/logic/QuotientTest.java
@@ -1,5 +1,7 @@
 package logic;
 
+import log.Log;
+import log.Urgency;
 import models.*;
 import org.junit.Test;
 
@@ -34,7 +36,7 @@ public class QuotientTest {
         assertEquals(quotient.getClocks().size(), 1);
         assertTrue(contains_clock_quo_new);
     }
-
+    
     @Test
     public void quotientConstructorShouldAddANewChannel() {
         // Arrange
@@ -59,7 +61,7 @@ public class QuotientTest {
         assertEquals(quotient.getInputs().size(), 1);
         assertTrue(contains_channel_i_new);
     }
-
+    
     @Test
     public void quotientShouldHaveInputsAsUnionOfLhsAndRhs() {
         // Arrange

--- a/test/logic/QuotientTest.java
+++ b/test/logic/QuotientTest.java
@@ -1,7 +1,5 @@
 package logic;
 
-import log.Log;
-import log.Urgency;
 import models.*;
 import org.junit.Test;
 
@@ -36,7 +34,7 @@ public class QuotientTest {
         assertEquals(quotient.getClocks().size(), 1);
         assertTrue(contains_clock_quo_new);
     }
-    
+
     @Test
     public void quotientConstructorShouldAddANewChannel() {
         // Arrange
@@ -61,7 +59,7 @@ public class QuotientTest {
         assertEquals(quotient.getInputs().size(), 1);
         assertTrue(contains_channel_i_new);
     }
-    
+
     @Test
     public void quotientShouldHaveInputsAsUnionOfLhsAndRhs() {
         // Arrange

--- a/test/models/VariousTest.java
+++ b/test/models/VariousTest.java
@@ -199,7 +199,6 @@ public class VariousTest {
     }
 
     @Test
-    @Ignore // Passes but fails on the CI
     public void testFromFramework4() throws FileNotFoundException {
         SimpleTransitionSystem C1,C2;
         Automaton[] list = JSONParser.parse("samples/json/DelayAdd",true);


### PR DESCRIPTION
Fixes #62 where the inconsistent location has an incorrect invariant. The fix for this was to introduce a global clock which, upon creation of a Quotient instance, is searched for. If this clock exists then it is reused in a new inconsistent location otherwise one is created. Also, flaky tests were happening as some tests at random times tried to reduce a terminal CDD this has been fixed by adding several checks in CDD for shortcut computations.

# Description
* [Quotient](https://github.com/Ecdar/j-Ecdar/blob/13f3f4af3accfe7b9050d3408bd5c06da6c2e5be/src/logic/Quotient.java#L20): Now reuses clock used by inconsistent locations.
* [UniqueNamedContainer](https://github.com/Ecdar/j-Ecdar/blob/13f3f4af3accfe7b9050d3408bd5c06da6c2e5be/src/logic/UniqueNamedContainer.java#L56): Has been updated to allow for global named items in its collection.
* [Automaton](https://github.com/Ecdar/j-Ecdar/blob/13f3f4af3accfe7b9050d3408bd5c06da6c2e5be/src/models/Automaton.java#L240): Making an automaton input enabled has been refactored and terminal CDD, which could be encountered, are now handled gracefully. With the additions in [CDD](https://github.com/Ecdar/j-Ecdar/blob/13f3f4af3accfe7b9050d3408bd5c06da6c2e5be/src/models/CDD.java#L514) I don't think the ``isTerminal`` check is required, but I still prefer having it.
* [QuotientTest](https://github.com/Ecdar/j-Ecdar/blob/13f3f4af3accfe7b9050d3408bd5c06da6c2e5be/test/logic/QuotientTest.java#L1): Now has tests to check whether clocks are being reused. 

# Opens
* I think the introduction of *global clocks* introduce the requirement for explicitly designing our scope rules.
* Instead of using [names](https://github.com/Ecdar/j-Ecdar/blob/13f3f4af3accfe7b9050d3408bd5c06da6c2e5be/src/models/Automaton.java#L10) for an Automaton I think we should use a symbol from a [symboltable](https://www.geeksforgeeks.org/symbol-table-compiler/).

# Related Issues
Closes #62 