### PR TITLE
Fix for  Gradle error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,8 @@ java{
     targetCompatibility = JavaVersion.VERSION_11
 }
 
+mainClassName = "JECDAR"
+
 dependencies {
     testImplementation "junit:junit:4.12"
     implementation 'io.grpc:grpc-netty-shaded:1.42.0'


### PR DESCRIPTION
The latest PR merge (#87) introduce a build error not caught by the CI pipeline.

This re-introduces the `mainClassName` Gradle attribute to resolve the issue mentioned above.